### PR TITLE
Check if chargeDate is null before calling yyyymmdd

### DIFF
--- a/src/GoCardless.js
+++ b/src/GoCardless.js
@@ -113,7 +113,7 @@ export default class GoCardless {
                 amount,
                 currency,
                 metadata,
-                charge_date: yyyymmdd(chargeDate),
+                charge_date: chargeDate && yyyymmdd(chargeDate),
                 reference: internalReference || '',
                 description: description || '',
                 links: {


### PR DESCRIPTION
Hi!

When chargeDate is null, the `yyyymmdd` function throws an error because you can't call a method on `null` (like `.getFullYear`). Besides that, I think it's pretty interesting to allow passing null to charge_date since GoCardless will send the payment as soon as possible.

Cheers!! ;-)